### PR TITLE
Update instruments supply crate. (1)

### DIFF
--- a/code/datums/supplypacks/nonessent.dm
+++ b/code/datums/supplypacks/nonessent.dm
@@ -55,7 +55,7 @@
 	contains = list(/obj/item/device/synthesized_instrument/synthesizer,
 					/obj/item/device/synthesized_instrument/guitar/multi,
 					/obj/item/device/synthesized_instrument/guitar,
-					/obj/item/device/synthesized_instrument/trumpet,)
+					/obj/item/device/synthesized_instrument/trumpet)
 	cost = 40
 	containername = "musical instrument crate"
 


### PR DESCRIPTION
Updated to include the functioning accoustic guitar in the instruments supply crate. Resolved a trailing comma.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->